### PR TITLE
インスタンスを先に増やすようにする

### DIFF
--- a/cmd/update-ami/main.go
+++ b/cmd/update-ami/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"log"
 	"os"
 
 	"github.com/urfave/cli"
 
 	"github.com/noritama73/update-ami/internal/handler"
 )
+
+func init() {
+	log.SetFlags(log.Lshortfile)
+}
 
 func main() {
 	app := cli.NewApp()
@@ -47,9 +52,10 @@ func main() {
 					Value: 20,
 					Usage: "delay of waiter config",
 				},
-				cli.BoolFlag{
-					Name:  "skip-abnormal-instance",
-					Usage: "if true, you can skip abnormal instences and continue the process",
+				cli.StringFlag{
+					Name:  "asg-name",
+					Value: "",
+					Usage: "associated asg",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -59,6 +65,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
+		log.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/update-ami/main.go
+++ b/cmd/update-ami/main.go
@@ -9,15 +9,11 @@ import (
 	"github.com/noritama73/update-ami/internal/handler"
 )
 
-func init() {
-	log.SetFlags(log.Lshortfile)
-}
-
 func main() {
 	app := cli.NewApp()
 	app.Name = "Update AMI"
 	app.Usage = "Replace ECS Cluster Instances for AMI Update"
-	app.Version = "1.1.0"
+	app.Version = "2.0.0"
 
 	app.Commands = []cli.Command{
 		{

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,11 +1,7 @@
 package handler
 
 import (
-	"bufio"
-	"fmt"
 	"log"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/urfave/cli"
@@ -76,9 +72,6 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 		return err
 	}
 	log.Printf("increased desired capacity: %d", newcap)
-	if !validateContinuingFromStdin() {
-		os.Exit(1)
-	}
 
 	for i, instance := range clusterInstances {
 		log.Println("**************************************************")
@@ -133,12 +126,3 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 	return nil
 }
 
-func validateContinuingFromStdin() bool {
-	fmt.Print("Continue? If yes, type exactly \"yes\": ")
-	s := bufio.NewScanner(os.Stdin)
-	s.Scan()
-	if s.Err() != nil {
-		panic("error in scannig stdin")
-	}
-	return strings.ToLower(s.Text()) == "yes"
-}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -87,22 +87,26 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 		log.Printf("Draining: %v", instance.InstanceID)
 		if err := ecsService.DrainContainerInstances(instance); err != nil {
 			log.Println(err)
+			continue
 		}
 
 		if err := ecsService.WaitUntilContainerInstanceDrained(instance, waiterConfig); err != nil {
 			log.Println(err)
+		} else {
+			log.Printf("Drained: %v", instance.InstanceID)
 		}
-		log.Printf("Drained: %v", instance.InstanceID)
 
 		if err := ecsService.DeregisterContainerInstance(instance); err != nil {
 			log.Println(err)
+		} else {
+			log.Printf("Deregistered: %v", instance.InstanceID)
 		}
-		log.Printf("Deregistered: %v", instance.InstanceID)
 
 		if err := ec2Service.TerinateInstance(instance); err != nil {
 			log.Println(err)
+		} else {
+			log.Printf("Terminated: %v", instance.InstanceID)
 		}
-		log.Printf("Terminated: %v", instance.InstanceID)
 
 		if (i + 1) == len(clusterInstances) {
 			break
@@ -121,6 +125,7 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 
 	if err := asgService.UpdateDesiredCapacity(asgName, int64(desiredCount)); err != nil {
 		log.Println("couldn't update desired capacity")
+		return err
 	}
 	log.Println("Reseted desired capacity")
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -55,7 +55,7 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 		return err
 	}
 	desiredCount := cap
-	log.Printf("cap: %d", cap)
+	log.Printf("Desired capacity: %d", cap)
 
 	if err := asgService.UpdateDesiredCapacity(asgName, int64(desiredCount+1)); err != nil {
 		log.Println("couldn't update desired capacity")
@@ -75,7 +75,7 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 		log.Println("couldn't describe autoscaling group")
 		return err
 	}
-	log.Printf("increase desired capacity: %d", newcap)
+	log.Printf("increased desired capacity: %d", newcap)
 	if !validateContinuingFromStdin() {
 		os.Exit(1)
 	}

--- a/internal/services/asg.go
+++ b/internal/services/asg.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+)
+
+type ASGService interface {
+	DescribeAutoScalingGroups(name string) (int64, error)
+	UpdateDesiredCapacity(name string, newCapacity int64) error
+}
+
+type asgService struct {
+	svc autoscalingiface.AutoScalingAPI
+}
+
+type DescribeAutoScalingGroupsOutput struct {
+	DesiredCapacity int64
+}
+
+func (s *asgService) DescribeAutoScalingGroups(name string) (int64, error) {
+	input := &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String(name)},
+	}
+	resp, err := s.svc.DescribeAutoScalingGroups(input)
+
+	return *resp.AutoScalingGroups[0].DesiredCapacity, err
+}
+
+func (s *asgService) UpdateDesiredCapacity(name string, newCapacity int64) error {
+	input := &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(name),
+		DesiredCapacity:      aws.Int64(newCapacity),
+	}
+	_, err := s.svc.UpdateAutoScalingGroup(input)
+
+	return err
+}
+
+var _ ASGService = (*asgService)(nil)

--- a/internal/services/ecs.go
+++ b/internal/services/ecs.go
@@ -12,7 +12,7 @@ type ECSService interface {
 	ListContainerInstances(cluster string) ([]ClusterInstance, error)
 	DrainContainerInstances(instance ClusterInstance) error
 	DeregisterContainerInstance(instance ClusterInstance) error
-	UpdateECSServiceByForce(instance ClusterInstance) error
+	UpdateECSServiceByForce(cluster string) error
 	WaitUntilContainerInstanceDrained(instance ClusterInstance, config CustomAWSWaiterConfig) error
 	WaitUntilNewInstanceRegistered(cluster string, desire int, config CustomAWSWaiterConfig) error
 }
@@ -80,9 +80,9 @@ func (s *ecsService) DeregisterContainerInstance(instance ClusterInstance) error
 	return err
 }
 
-func (s *ecsService) UpdateECSServiceByForce(instance ClusterInstance) error {
+func (s *ecsService) UpdateECSServiceByForce(cluster string) error {
 	dsInput := &ecs.ListServicesInput{
-		Cluster: aws.String(instance.Cluster),
+		Cluster: aws.String(cluster),
 	}
 	dsResp, err := s.svc.ListServices(dsInput)
 	if err != nil {
@@ -90,7 +90,7 @@ func (s *ecsService) UpdateECSServiceByForce(instance ClusterInstance) error {
 	}
 	for _, serviceArn := range dsResp.ServiceArns {
 		usInput := &ecs.UpdateServiceInput{
-			Cluster:            aws.String(instance.Cluster),
+			Cluster:            aws.String(cluster),
 			Service:            aws.String(*serviceArn),
 			ForceNewDeployment: aws.Bool(true),
 		}

--- a/internal/services/session.go
+++ b/internal/services/session.go
@@ -1,22 +1,25 @@
 package services
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/urfave/cli"
 )
 
-func NewSessions(c *cli.Context) (EC2Service, ECSService) {
+func NewServices(c *cli.Context) (EC2Service, ECSService, ASGService) {
 	opt := session.Options{
 		Config:                  *aws.NewConfig(),
 		Profile:                 c.String("profile"),
 		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
-		AssumeRoleDuration:      3600,
+		AssumeRoleDuration:      3600 * time.Second,
 		SharedConfigState:       session.SharedConfigEnable,
 	}
 	sess := session.Must(session.NewSessionWithOptions(opt))
-	return &ec2Service{svc: ec2.New(sess)}, &ecsService{ecs.New(sess)}
+	return &ec2Service{svc: ec2.New(sess)}, &ecsService{svc: ecs.New(sess)}, &asgService{svc: autoscaling.New(sess)}
 }


### PR DESCRIPTION
既存の総リソースが足りずタスクの再分配ができない問題を回避