### PR TITLE
コンテナインスタンスで使用中のAMI情報を確認するコマンドの追加

### DIFF
--- a/cmd/update-ami/main.go
+++ b/cmd/update-ami/main.go
@@ -13,7 +13,6 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "Update AMI"
 	app.Usage = "Replace ECS Cluster Instances for AMI Update"
-	app.Version = "2.0.0"
 
 	app.Commands = []cli.Command{
 		{
@@ -21,22 +20,25 @@ func main() {
 			Usage: "replace cluster instances",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:   "cluster",
-					Value:  "",
-					Usage:  "Name of target ECS cluster",
-					EnvVar: "AWS_ECS_CLUSTER",
+					Name:     "cluster",
+					Value:    "",
+					Usage:    "Name of target ECS cluster",
+					EnvVar:   "AWS_ECS_CLUSTER",
+					Required: true,
 				},
 				cli.StringFlag{
-					Name:   "region",
-					Value:  "",
-					Usage:  "AWS region",
-					EnvVar: "AWS_REGION",
+					Name:     "region",
+					Value:    "",
+					Usage:    "AWS region",
+					EnvVar:   "AWS_REGION",
+					Required: true,
 				},
 				cli.StringFlag{
-					Name:   "profile",
-					Value:  "",
-					Usage:  "AWS profile",
-					EnvVar: "AWS_PROFILE",
+					Name:     "profile",
+					Value:    "",
+					Usage:    "AWS profile",
+					EnvVar:   "AWS_PROFILE",
+					Required: true,
 				},
 				cli.IntFlag{
 					Name:  "max-attempt",
@@ -49,13 +51,44 @@ func main() {
 					Usage: "delay of waiter config",
 				},
 				cli.StringFlag{
-					Name:  "asg-name",
-					Value: "",
-					Usage: "associated asg",
+					Name:   "asg-name",
+					Value:  "",
+					EnvVar: "AWS_ASG_NAME",
+					Usage:  "associated asg: if not set, this will be the same value as cluster",
 				},
 			},
 			Action: func(c *cli.Context) error {
 				return handler.ReplaceClusterInstnces(c)
+			},
+		},
+		{
+			Name:  "describe-ami",
+			Usage: "Describe ami used by container instance",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     "cluster",
+					Value:    "",
+					Usage:    "Name of target ECS cluster",
+					EnvVar:   "AWS_ECS_CLUSTER",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:     "region",
+					Value:    "",
+					Usage:    "AWS region",
+					EnvVar:   "AWS_REGION",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:     "profile",
+					Value:    "",
+					Usage:    "AWS profile",
+					EnvVar:   "AWS_PROFILE",
+					Required: true,
+				},
+			},
+			Action: func(c *cli.Context) error {
+				return handler.DescribeCurrentMachineImage(c)
 			},
 		},
 	}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -123,5 +124,32 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 	log.Println("Reseted desired capacity")
 
 	log.Println("Success!")
+	return nil
+}
+
+func DescribeCurrentMachineImage(c *cli.Context) error {
+	ec2Service, ecsService, _ := services.NewServices(c.String("profile"))
+	log.Println("successfully initialize sessions")
+
+	cluster := c.String("cluster")
+
+	instances, err := ecsService.ListContainerInstances(cluster)
+	if err != nil {
+		return err
+	}
+	if len(instances) < 1 {
+		return fmt.Errorf("there is no instance: %s", cluster)
+	}
+
+	imageID, err := ec2Service.GetImageID(instances[0])
+	if err != nil {
+		return err
+	}
+	mi, err := ec2Service.DescribeImages(imageID)
+	if err != nil {
+		return err
+	}
+	outputMachineImage(mi, cluster)
+
 	return nil
 }

--- a/internal/handler/usecase.go
+++ b/internal/handler/usecase.go
@@ -1,0 +1,16 @@
+package handler
+
+import (
+	"fmt"
+
+	"github.com/noritama73/update-ami/internal/services"
+)
+
+func outputMachineImage(mi services.MachineImage, cluster string) {
+	fmt.Printf("******************Image used in %s******************\n", cluster)
+	fmt.Printf("Name: %s\n", mi.Name)
+	fmt.Printf("Description: %s\n", mi.Description)
+	fmt.Printf("ImageID: %s\n", mi.ImageID)
+	fmt.Printf("Architecture: %s\n", mi.Architecture)
+	fmt.Printf("PlantFormDatails: %s\n", mi.PlatformDetails)
+}

--- a/internal/services/ec2.go
+++ b/internal/services/ec2.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -8,6 +10,9 @@ import (
 
 type EC2Service interface {
 	TerinateInstance(instance ClusterInstance) error
+
+	GetImageID(instance ClusterInstance) (string, error)
+	DescribeImages(id string) (MachineImage, error)
 }
 
 type ec2Service struct {
@@ -20,6 +25,52 @@ func (s *ec2Service) TerinateInstance(instance ClusterInstance) error {
 	}
 	_, err := s.svc.TerminateInstances(input)
 	return err
+}
+
+func (s *ec2Service) GetImageID(instance ClusterInstance) (string, error) {
+	input := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{aws.String(instance.InstanceID)},
+	}
+	res, err := s.svc.DescribeInstances(input)
+	if err != nil {
+		return "", err
+	}
+	if len(res.Reservations) < 1 {
+		return "", fmt.Errorf("there is no reservation: %s", instance.InstanceID)
+	}
+	if len(res.Reservations[0].Instances) < 1 {
+		return "", fmt.Errorf("there is no instance: %s", instance.InstanceID)
+	}
+
+	return *res.Reservations[0].Instances[0].ImageId, nil
+}
+
+type MachineImage struct {
+	Architecture    string
+	ImageID         string
+	PlatformDetails string
+	Description     string
+	Name            string
+}
+
+func (s *ec2Service) DescribeImages(id string) (MachineImage, error) {
+	input := &ec2.DescribeImagesInput{
+		ImageIds: []*string{aws.String(id)},
+	}
+	res, err := s.svc.DescribeImages(input)
+	if len(res.Images) < 1 {
+		return MachineImage{}, fmt.Errorf("there is no image: %s", id)
+	}
+	image := res.Images[0]
+	machineImage := MachineImage{
+		Architecture:    *image.Architecture,
+		ImageID:         *image.ImageId,
+		PlatformDetails: *image.PlatformDetails,
+		Description:     *image.Description,
+		Name:            *image.Name,
+	}
+
+	return machineImage, err
 }
 
 var _ EC2Service = (*ec2Service)(nil)

--- a/internal/services/ec2_test.go
+++ b/internal/services/ec2_test.go
@@ -9,19 +9,24 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/noritama73/update-ami/internal/mocks"
 )
 
 const (
-	testEc2InstanceID = "i-XXXXXXXXXX"
+	testEc2InstanceID    = "i-XXXXXXXXXX"
+	testEc2InstanceIDErr = "i-EEEEEEEEEE"
+
+	testImageID    = "ami-XXXXXXXXXX"
+	testImageIDErr = "ami-EEEEEEEEEE"
 )
 
 func newMockEc2Service(iface ec2iface.EC2API) EC2Service {
 	return &ec2Service{svc: iface}
 }
 
-func Test_Ec2TerminateInstance(t *testing.T) {
+func Test_TerminateInstance(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
@@ -32,7 +37,9 @@ func Test_Ec2TerminateInstance(t *testing.T) {
 		mockEc2Iface.EXPECT().TerminateInstances(&ec2.TerminateInstancesInput{
 			InstanceIds: []*string{aws.String(testEc2InstanceID)},
 		}).Return(nil, nil).Times(1),
-		mockEc2Iface.EXPECT().TerminateInstances(gomock.Any()).Return(nil, fmt.Errorf("error")).Times(1),
+		mockEc2Iface.EXPECT().TerminateInstances(&ec2.TerminateInstancesInput{
+			InstanceIds: []*string{aws.String(testEc2InstanceIDErr)},
+		}).Return(nil, fmt.Errorf("error")).Times(1),
 	)
 
 	mockEc2Service := newMockEc2Service(mockEc2Iface)
@@ -45,7 +52,105 @@ func Test_Ec2TerminateInstance(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		assert.Error(t, mockEc2Service.TerinateInstance(ClusterInstance{
-			InstanceID: "",
+			InstanceID: testEc2InstanceIDErr,
 		}))
+	})
+}
+
+func Test_GetImageID(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockEc2Iface := mocks.NewMockEC2API(ctrl)
+	gomock.InOrder(
+		mockEc2Iface.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(testEc2InstanceID)},
+		}).Return(&ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{
+				{
+					Instances: []*ec2.Instance{
+						{
+							ImageId: aws.String(testImageID),
+						},
+					},
+				},
+			},
+		}, nil).Times(1),
+		mockEc2Iface.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(testEc2InstanceIDErr)},
+		}).Return(&ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{},
+		}, nil).Times(1),
+		mockEc2Iface.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(testEc2InstanceIDErr)},
+		}).Return(&ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{
+				{
+					Instances: []*ec2.Instance{},
+				},
+			},
+		}, nil).Times(1),
+	)
+
+	mockEc2Service := newMockEc2Service(mockEc2Iface)
+
+	t.Run("normal", func(t *testing.T) {
+		imageID, err := mockEc2Service.GetImageID(ClusterInstance{InstanceID: testEc2InstanceID})
+		require.NoError(t, err)
+		assert.Equal(t, testImageID, imageID)
+	})
+
+	t.Run("no reservation", func(t *testing.T) {
+		_, err := mockEc2Service.GetImageID(ClusterInstance{InstanceID: testEc2InstanceIDErr})
+		assert.Equal(t, fmt.Errorf("there is no reservation: %s", testEc2InstanceIDErr), err)
+	})
+
+	t.Run("no instance", func(t *testing.T) {
+		_, err := mockEc2Service.GetImageID(ClusterInstance{InstanceID: testEc2InstanceIDErr})
+		assert.Equal(t, fmt.Errorf("there is no instance: %s", testEc2InstanceIDErr), err)
+	})
+}
+
+func Test_DescribeImages(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockEc2Iface := mocks.NewMockEC2API(ctrl)
+	gomock.InOrder(
+		mockEc2Iface.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+			ImageIds: []*string{aws.String(testImageID)},
+		}).Return(&ec2.DescribeImagesOutput{
+			Images: []*ec2.Image{
+				{
+					Architecture:    aws.String(""),
+					ImageId:         aws.String(testImageID),
+					PlatformDetails: aws.String(""),
+					Description:     aws.String(""),
+					Name:            aws.String(""),
+				},
+			},
+		}, nil).Times(1),
+		mockEc2Iface.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+			ImageIds: []*string{aws.String(testImageIDErr)},
+		}).Return(&ec2.DescribeImagesOutput{
+			Images: []*ec2.Image{},
+		}, nil).Times(1),
+	)
+
+	mockEc2Service := newMockEc2Service(mockEc2Iface)
+
+	t.Run("normal", func(t *testing.T) {
+		image, err := mockEc2Service.DescribeImages(testImageID)
+		require.NoError(t, err)
+		assert.Equal(t, testImageID, image.ImageID)
+	})
+
+	t.Run("no image", func(t *testing.T) {
+		_, err := mockEc2Service.DescribeImages(testImageIDErr)
+		assert.Equal(t, fmt.Errorf("there is no image: %s", testImageIDErr), err)
 	})
 }


### PR DESCRIPTION
## 概要
* クラスタを指定すると，そこのコンテナインスタンスが使用しているAMIの情報を取得する
```
update-ami describe-ami --region <region> --profile <profile> --cluster <cluster>
```

## 影響範囲


## テスト状況


## 引き継ぐ事項

- [ ] xxx