### PR TITLE
使用中のLaunch TemplateまたはAWSのOverrideと稼働中のインスタンスとでタイプが異なる場合にwarningを出す

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -51,9 +51,11 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 		log.Println("couldn't describe autoscaling group")
 		return err
 	}
+	checkDifferenceBetweenAsgAndInstances(asg)
 	log.Printf("Desired capacity: %d", *asg.DesiredCapacity)
 	log.Printf("Max size: %d", *asg.MaxSize)
 
+	// 更新開始、ここからは中途半端な状態で終わらないように注意
 	if err := asgService.UpdateAutoScalingGroup(asgName, int64(*asg.DesiredCapacity+1), int64(*asg.MaxSize+1)); err != nil {
 		log.Println("couldn't update autoscaling group")
 		return err

--- a/internal/handler/usecase.go
+++ b/internal/handler/usecase.go
@@ -24,7 +24,7 @@ func checkDifferenceBetweenAsgAndInstances(asg *autoscaling.Group) {
 	for _, override := range asg.MixedInstancesPolicy.LaunchTemplate.Overrides {
 		for _, i := range asg.Instances {
 			if *i.InstanceType != *override.InstanceType {
-				log.Printf("InstanceType is different; Instance: %s, asg: %s", *i.InstanceType, *override.InstanceType)
+				log.Printf("\x1b[33mInstanceType is different; Instance: %s, asg: %s\x1b[0m", *i.InstanceType, *override.InstanceType)
 				if !checkWantToContinue() {
 					os.Exit(0)
 				}

--- a/internal/handler/usecase.go
+++ b/internal/handler/usecase.go
@@ -2,8 +2,13 @@ package handler
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"strings"
 
 	"github.com/noritama73/update-ami/internal/services"
+
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
 
 func outputMachineImage(mi services.MachineImage, cluster string) {
@@ -13,4 +18,33 @@ func outputMachineImage(mi services.MachineImage, cluster string) {
 	fmt.Printf("ImageID: %s\n", mi.ImageID)
 	fmt.Printf("Architecture: %s\n", mi.Architecture)
 	fmt.Printf("PlantFormDatails: %s\n", mi.PlatformDetails)
+}
+
+func checkDifferenceBetweenAsgAndInstances(asg *autoscaling.Group) {
+	for _, override := range asg.MixedInstancesPolicy.LaunchTemplate.Overrides {
+		for _, i := range asg.Instances {
+			if *i.InstanceType != *override.InstanceType {
+				log.Printf("InstanceType is different; Instance: %s, asg: %s", *i.InstanceType, *override.InstanceType)
+				if !checkWantToContinue() {
+					os.Exit(0)
+				}
+			}
+		}
+	}
+}
+
+// 処理を続けたいか中断したいかを標準入力から受け付ける
+// 中断時に後処理が必要な場合は、呼び出し元でそれを行ってからexitする
+func checkWantToContinue() bool {
+	fmt.Print("Continue? (y/n): ")
+	var input string
+	_, err := fmt.Scan(&input) // 3つの入力値を受け付ける
+	if err != nil {
+		panic(err)
+	}
+	if strings.ToLower(input) != "y" {
+		log.Println("Aborted")
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
## 概要

fix: #31 

ASGで指定されているインスタンスタイプと、紐づいて稼働中のインスタンスのタイプが異なっている場合にwarningを出す
https://awscli.amazonaws.com/v2/documentation/api/latest/reference/autoscaling/describe-auto-scaling-groups.html

インスタンスの入れ替えを行う前のチェックなので、後片付けなしでexitしてしまってOK

再現が難しかったので一旦こうしてみた
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/52298d93-8a8b-4715-b0e6-5368c4098456">


稼働イメージ
```
2024/08/18 14:32:26 successfully initialize sessions
Assume Role MFA token code: zzzzzz
2024/08/18 14:32:33 Instance is found: i-xxxxxxxxxxxxxxxxx
2024/08/18 14:32:33 InstanceType is different; Instance: t3a.nano, asg: t3a.micro
Continue? (y/n): n
2024/08/18 14:32:41 Aborted
```

## 影響範囲


## テスト状況


## 引き継ぐ事項

- [ ] xxx