### PR TITLE
インスタンスTerminate時に待つ

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -101,9 +101,12 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 
 		if err := ec2Service.TerinateInstance(instance); err != nil {
 			log.Println(err)
-		} else {
-			log.Printf("Terminated: %v", instance.InstanceID)
 		}
+
+		if err := ec2Service.WaitUntilInstanceTerminated(instance.InstanceID, waiterConfig); err != nil {
+			log.Printf("instance %s is failed to be terminated", instance.InstanceID)
+		}
+		log.Printf("Terminated: %v", instance.InstanceID)
 
 		if (i + 1) == len(clusterInstances) {
 			break

--- a/internal/services/ec2.go
+++ b/internal/services/ec2.go
@@ -1,15 +1,19 @@
 package services
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
 
 type EC2Service interface {
 	TerinateInstance(instance ClusterInstance) error
+	WaitUntilInstanceTerminated(instanceID string, config CustomAWSWaiterConfig) error
 
 	GetImageID(instance ClusterInstance) (string, error)
 	DescribeImages(id string) (MachineImage, error)
@@ -25,6 +29,18 @@ func (s *ec2Service) TerinateInstance(instance ClusterInstance) error {
 	}
 	_, err := s.svc.TerminateInstances(input)
 	return err
+}
+
+func (s *ec2Service) WaitUntilInstanceTerminated(instanceID string, config CustomAWSWaiterConfig) error {
+	input := &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{aws.String(instanceID)},
+	}
+	return s.svc.WaitUntilInstanceTerminatedWithContext(
+		context.TODO(),
+		input,
+		request.WithWaiterDelay(request.ConstantWaiterDelay(time.Duration(config.Delay))),
+		request.WithWaiterMaxAttempts(config.MaxAttempts),
+	)
 }
 
 func (s *ec2Service) GetImageID(instance ClusterInstance) (string, error) {

--- a/internal/services/ec2.go
+++ b/internal/services/ec2.go
@@ -38,8 +38,8 @@ func (s *ec2Service) WaitUntilInstanceTerminated(instanceID string, config Custo
 	return s.svc.WaitUntilInstanceTerminatedWithContext(
 		context.TODO(),
 		input,
-		request.WithWaiterDelay(request.ConstantWaiterDelay(5*time.Minute)), // 1分かかるケースがあったので、固定で5分は待っておく
-		request.WithWaiterMaxAttempts(config.MaxAttempts),
+		request.WithWaiterDelay(request.ConstantWaiterDelay(time.Duration(config.Delay)*time.Second)),
+		request.WithWaiterMaxAttempts(60*5/config.Delay), // 1分かかるケースがあったので、固定で5分は待っておく
 	)
 }
 

--- a/internal/services/ec2.go
+++ b/internal/services/ec2.go
@@ -38,7 +38,7 @@ func (s *ec2Service) WaitUntilInstanceTerminated(instanceID string, config Custo
 	return s.svc.WaitUntilInstanceTerminatedWithContext(
 		context.TODO(),
 		input,
-		request.WithWaiterDelay(request.ConstantWaiterDelay(time.Duration(config.Delay))),
+		request.WithWaiterDelay(request.ConstantWaiterDelay(5*time.Minute)), // 1分かかるケースがあったので、固定で5分は待っておく
 		request.WithWaiterMaxAttempts(config.MaxAttempts),
 	)
 }


### PR DESCRIPTION
## 概要

タイトル通り
特に最後のインスタンスの場合、これを待たずにループを抜けると、タスクの乗ったインスタンスがASGに落とされてしまう
waiterの最大試行回数、delayはecsのものと共通とする

## 影響範囲


## テスト状況


## 引き継ぐ事項

- [ ] xxx