### PR TITLE
最後のインスタンスはASGからデタッチして、managedの仕組みからterminateされないようにする

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -20,7 +20,8 @@ import (
 // 7.サービスを強制更新
 // 8.ちょっと待つ
 // 9.4.に戻る
-// 10.古いインスタンスをドレインし切るタイミングでmax capacityとdesired countを1減らす（元に戻す）
+// 10.最後のインスタンスはASGのTerminateInstanceInAutoScalingGroup(ShouldDecrementDesiredCapacity=true)で
+//    terminateとdesired countの縮小をアトミックに行い、その後max capacityを元に戻す
 /////////////////////////////////////////////////////////////////////////////////////////////
 
 func ReplaceClusterInstnces(c *cli.Context) error {
@@ -99,14 +100,29 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 			log.Printf("Deregistered: %v", instance.InstanceID)
 		}
 
+		isLastInstance := (i + 1) == len(clusterInstances)
+
+		if isLastInstance {
+			// 最後のインスタンスはASG経由でterminateし、desired countをアトミックに縮小する
+			if err := asgService.TerminateInstanceInAutoScalingGroup(instance.InstanceID, true); err != nil {
+				log.Println(err)
+				return err
+			}
+			log.Printf("Terminated via ASG (with desired decrement): %v", instance.InstanceID)
+
+			// max capacityだけ元に戻す
+			if err := asgService.UpdateAutoScalingGroup(asgName, int64(*asg.DesiredCapacity), *asg.MaxSize); err != nil {
+				log.Println("couldn't update autoscaling group")
+				return err
+			}
+			log.Println("Reset autoscaling group")
+			break
+		}
+
 		if err := ec2Service.TerinateInstance(instance); err != nil {
 			log.Println(err)
 		} else {
 			log.Printf("Terminated: %v", instance.InstanceID)
-		}
-
-		if (i + 1) == len(clusterInstances) {
-			break
 		}
 
 		log.Println("waiting for a new instance to be registered")
@@ -119,12 +135,6 @@ func ReplaceClusterInstnces(c *cli.Context) error {
 		}
 		time.Sleep(10 * time.Second)
 	}
-
-	if err := asgService.UpdateAutoScalingGroup(asgName, int64(*asg.DesiredCapacity), *asg.MaxSize); err != nil {
-		log.Println("couldn't update autoscaling group")
-		return err
-	}
-	log.Println("Reset autoscaling group")
 
 	log.Println("Success!")
 	return nil

--- a/internal/services/asg.go
+++ b/internal/services/asg.go
@@ -11,6 +11,7 @@ import (
 type ASGService interface {
 	DescribeAutoScalingGroup(name string) (*autoscaling.Group, error)
 	UpdateAutoScalingGroup(name string, desiredCapacity, maxSize int64) error
+	TerminateInstanceInAutoScalingGroup(instanceID string, shouldDecrementDesiredCapacity bool) error
 }
 
 type asgService struct {
@@ -47,6 +48,15 @@ func (s *asgService) UpdateAutoScalingGroup(name string, desiredCapacity, maxSiz
 	}
 	_, err := s.svc.UpdateAutoScalingGroup(input)
 
+	return err
+}
+
+func (s *asgService) TerminateInstanceInAutoScalingGroup(instanceID string, shouldDecrementDesiredCapacity bool) error {
+	input := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     aws.String(instanceID),
+		ShouldDecrementDesiredCapacity: aws.Bool(shouldDecrementDesiredCapacity),
+	}
+	_, err := s.svc.TerminateInstanceInAutoScalingGroup(input)
 	return err
 }
 


### PR DESCRIPTION
## 概要

* EC2の DescribeInstances が terminated を返すタイミングと、ASGがそのインスタンスの消失を認識するタイミングには差がある
* ASGは独自のポーリング間隔でインスタンス状態を確認しているため、EC2側で terminated になっていてもASGの内部リストにはまだ残っている、という時間帯が存在する
* WaitUntilInstanceTerminated →ASG設定を戻す、というアプローチでも同じレースコンディションが起きる可能性がある

## 影響範囲


## テスト状況

別途動作確認済み
ASGのActivity logに出ている、ASGがインスタンスのterminatedを検知した時間と、update-amiのログに出ているterminatedの時間が一致している

## 引き継ぐ事項

- [ ] xxx